### PR TITLE
Add support for Elasticsearch 5.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+- '3.5'
+- '3.6'
+addons:
+  apt:
+    packages:
+      - oracle-java8-set-default
+before_install:
+- curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.4.0.deb
+  && sudo dpkg -i --force-confnew elasticsearch-5.4.0.deb && sudo service elasticsearch
+  restart
+install:
+- pip install -r requirements.txt
+before_script:
+- sleep 30
+script:
+- nosetests
+notifications:
+  slack:
+    secure: JmRYLg4niVnu8YewGRByAZhDQsTHT7T/H26lKXatR48999cKwPPctkpNjyV/+O0ZMiNA1dATCSZa9x3cd38Vhana7BqruO8K3LrDlWjPlIYyrZDMO72Daqd78KdwGtlFJm7XmMo5FDlC2SWrdNwdrxw1Js8Nhv+U5BbFONhMB1U/yJOYKFU5Ez00VcyQXpNxfTkgDr0O2om2fsSaP4Xtz3Z5CpB8Snbe7SjmDYjUz9H1lT4YT3L008jxAHdZbPct2xSUHl+M/zJHTtppR7Xf2d2RgYXlhcBtPF7+7dEEXa0RCQ+KFZbpm9AGpEAwzghUVyfVxtP0N0iMeyW0S0c4a/DCRivVf/ia//pePBU2AkjMrAbPIqI2xb4BO/NIk7VRQDumjXpuSaQn5LSXEWCgNMgIXAMQfYIJhDDupDO6ErGjIGlDnhYvaHHZYqmSkfO06OV9hH/cLJhU4ag6LRuE/Rtanh3YNlr+SBsYpSdh//6/steGx1ukOfmkYQk0H/3LZ5/FpE9LBp6z8teSac9wTHA3HNptx+uNQOHRr2DL/P/TZ9J1pL1mxSFpgY+wDBAl4D64VFXMRbbSZd5PxwInCnpZzQKCDdG4uDogIoTL4MxfHZW/bE603E9iwlJ94ZSsWMYJXKG0cUo3TOkWGoKNxq3eL8rS0tq6Wmg8YdWY/SA=

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,16 @@ elastic-companion
 
 A command-line tool and API for various Elasticsearch operations.
 
+[![Build Status](https://travis-ci.org/getconversio/elastic-companion.svg?branch=master)](https://travis-ci.org/getconversio/elastic-companion)
+
 Install
 -------
 
     pip install elastic-companion
+
+**Note**: The 1.X versions of elastic-companion support Elasticsearch 1.X and
+the 5.X versions support Elasticsearch 5.X. This is similar to the versioning
+of the official library
 
 Commands
 --------

--- a/companion/api/reindex.py
+++ b/companion/api/reindex.py
@@ -57,7 +57,6 @@ def date_reindex(url, source_index_name, target_index_name, date_field=None,
                         index=source_index_name,
                         query=query,
                         scroll='5m',
-                        fields=('_source', '_parent', '_routing', '_timestamp'),
                         **scan_kwargs)
 
     def _docs_to_operations(hits):

--- a/companion/cli/deletebulk.py
+++ b/companion/cli/deletebulk.py
@@ -3,7 +3,7 @@
 For Example:
 
     >>> companion delete myindex mydoctype -q \
-    >>> '{"query":{"filtered":{"filter":{"range":{"timestamp":{"gt":"2015"}}}}}'
+    >>> '{"query":{"bool":{"filter":{"range":{"timestamp":{"gt":"2015"}}}}}'
 
 For more complicated queries, you can store the query in a JSON file:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '2'
 
 services:
   elasticsearch:
-    image: elasticsearch:1.7.5
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
+    volumes:
+      - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     ports:
       - "9200:9200"
 

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,0 +1,2 @@
+http.host: 0.0.0.0
+xpack.security.enabled: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 args==0.1.0
 boto3==1.4.0
 botocore==1.4.50
-certifi==2016.8.31
+certifi>=2016.8.31
 clint==0.5.1
 docutils==0.12
-elasticsearch==1.9.0
+elasticsearch>=5.0.0,<6.0.0
 jmespath==0.9.0
 nose==1.3.7
 pkginfo==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='elastic-companion',
-    version='1.4.0',
+    version='5.0.0',
     description='Useful commands for Elasticsearch',
     long_description=long_description,
-    url='https://github.com/receiptful/elastic-companion',
-    author='Receiptful',
-    author_email='dev@receiptful.com',
+    url='https://github.com/getconversio/elastic-companion',
+    author='Conversio',
+    author_email='dev@conversio.com',
     license='MIT',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -24,8 +24,8 @@ setup(
     keywords='elasticsearch cli',
     packages=['companion', 'companion.api', 'companion.cli'],
     install_requires=[
-        'elasticsearch>=1.9.0,<2.0.0',
-        'certifi==2016.8.31',
+        'elasticsearch>=5.0.0,<6.0.0',
+        'certifi>=2016.8.31',
         'boto3==1.4.0',
         'python-dateutil==2.5.3'
     ],

--- a/test/test_api_deletebulk.py
+++ b/test/test_api_deletebulk.py
@@ -1,7 +1,6 @@
 """Bulk delete test functions."""
 from unittest import TestCase
 
-from companion import error
 from companion.api import deletebulk, util
 
 from . import create_test_data, es_url
@@ -55,7 +54,7 @@ class TestDeleteByQuery(TestCase):
         # Deletes everything after 1/1
         query = {
             "query": {
-                "filtered": {
+                "bool": {
                     "filter": {
                         "range": {
                             "timestamp": {

--- a/test/test_api_reindex.py
+++ b/test/test_api_reindex.py
@@ -1,5 +1,4 @@
 """Reindex test functions."""
-import os
 from unittest import TestCase
 
 from companion.api import reindex, util
@@ -84,7 +83,7 @@ class TestDateReindex(TestCase):
         # Re-index documents created after 2015-01-01.
         query = {
             "query": {
-                "filtered": {
+                "bool": {
                     "filter": {
                         "range": {
                             "timestamp": {


### PR DESCRIPTION
This commit it the first on a new 5.X branch that adds support for
Elasticsearch 5.X.

There are no new features on this commit except added support for
travis-ci.